### PR TITLE
ignore the Klassenfotos_cropped output directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -258,5 +258,6 @@ cython_debug/
 #.idea/
 
 Klassenfotos/
+Klassenfotos_cropped/
 Klassenfotos_test/
 student_photos_list.pdf


### PR DESCRIPTION
like `student_photos_list.pdf` it is created by the script and contains sensitive data, so I think it makes sense that it should be ignored by default